### PR TITLE
fix(errors): fixes #133: standardize error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ See [stylelint options](http://stylelint.io/user-guide/node-api/#options) for th
 * `lintDirtyModulesOnly`: Lint only changed files, skip lint on start. Default: `false`
 * [`syntax`](https://stylelint.io/user-guide/node-api/#syntax): e.g. use `'scss'` to lint .scss files. Default: `undefined`
 
+## Use With Webpack Reporters
+
+When using this plugin with a webpack reporter, such as
+[webpack-stylish](https://github.com/webpack-contrib/webpack-stylish), you must
+set the `formatter` option to `'webpack'` for proper error and warning output. eg:
+
+```js
+plugins: [
+  new StyleLintPlugin({
+    formatter: 'webpack'
+  })
+]
+
+```
+
 ## Errors
 
 The plugin will dump full reporting of errors.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var formatter = require('stylelint').formatters.string;
 var runCompilation = require('./lib/run-compilation');
 var LintDirtyModulesPlugin = require('./lib/lint-dirty-modules-plugin');
 var defaultFilesGlob = require('./lib/constants').defaultFilesGlob;
+var webpackFormatter = require('./lib/formatter-webpack');
 
 function apply (options, compiler) {
   options = options || {};
@@ -25,6 +26,10 @@ function apply (options, compiler) {
     }),
     context: context
   });
+
+  if (options.formatter === 'webpack') {
+    options.formatter = webpackFormatter;
+  }
 
   if (options.lintDirtyModulesOnly) {
     new LintDirtyModulesPlugin(compiler, options); // eslint-disable-line no-new

--- a/lib/StylelintPluginError.js
+++ b/lib/StylelintPluginError.js
@@ -1,0 +1,15 @@
+'use strict';
+
+let Base = Error;
+
+try {
+  // this wasn't added to webpack until v2.5.0, and peerDeps state this package
+  // supports webpack@1.x.
+  Base = require('webpack/lib/WebpackError');
+} catch (e) { }
+
+module.exports = class StylelintPluginError extends Base {
+  constructor(message) {
+    super(message);
+  }
+};

--- a/lib/StylelintPluginError.js
+++ b/lib/StylelintPluginError.js
@@ -1,12 +1,14 @@
 'use strict';
 
-let Base = Error;
+let Base;
 
 try {
   // this wasn't added to webpack until v2.5.0, and peerDeps state this package
   // supports webpack@1.x.
   Base = require('webpack/lib/WebpackError');
-} catch (e) { }
+} catch (e) {
+  Base = Error;
+}
 
 module.exports = class StylelintPluginError extends Base {
   constructor(message) {

--- a/lib/formatter-webpack.js
+++ b/lib/formatter-webpack.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const StylelintPluginError = require('./StylelintPluginError');
+
+module.exports = function webpack (items) {
+  const result = [];
+
+  for (const item of items) {
+    const file = item.source;
+
+    for (const warning of item.warnings) {
+      const line = warning.line;
+      const column = warning.column;
+      const text = warning.text;
+      const message = file + '\n' + line + ':' + column + ' ' + text;
+
+      result.push(new StylelintPluginError(message));
+    }
+  }
+
+  return result;
+};

--- a/lib/formatter-webpack.js
+++ b/lib/formatter-webpack.js
@@ -12,7 +12,7 @@ module.exports = function webpack (items) {
       const line = warning.line;
       const column = warning.column;
       const text = warning.text;
-      const message = file + '\n' + line + ':' + column + ' ' + text;
+      const message = file + '\n' + line + ':' + column + ' stylelint: ' + text;
 
       result.push(new StylelintPluginError(message));
     }

--- a/lib/formatter-webpack.js
+++ b/lib/formatter-webpack.js
@@ -16,6 +16,11 @@ module.exports = function webpack (items) {
 
       result.push(new StylelintPluginError(message));
     }
+
+    for (const warning of item.invalidOptionWarnings) {
+      const message = 'stylelint\n0:0 ' + warning.text;
+      result.push(new StylelintPluginError(message));
+    }
   }
 
   return result;

--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -29,13 +29,13 @@ module.exports = function runCompilation (options, compiler, done) {
       var results = lint.results;
 
       if (options.emitErrors === false) {
-        warnings = results.filter(R.either(fileHasErrors, fileHasWarnings));
+        problems.warnings = results.filter(R.either(fileHasErrors, fileHasWarnings));
       } else {
-        warnings = results.filter(R.both(R.complement(fileHasErrors), fileHasWarnings));
-        errors = results.filter(fileHasErrors);
+        problems.warnings = results.filter(R.both(R.complement(fileHasErrors), fileHasWarnings));
+        problems.errors = results.filter(fileHasErrors);
       }
 
-      if (options.failOnError && errors.length) {
+      if (options.failOnError && problems.errors.length) {
         done(new Error(errorMessage));
       } else {
         done();
@@ -49,11 +49,11 @@ module.exports = function runCompilation (options, compiler, done) {
       warnings = [];
     }
 
-    if (errors.length) {
-      compilation.errors.push(new Error(options.formatter(errors)));
-      errors = [];
+      problems[type] = [];
     }
 
+    format('warnings');
+    format('errors');
     next();
   };
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "globals": [
       "getPath",
       "expect"
+    ],
+    "ignore": [
+      "/lib/StylelintPluginError.js"
     ]
   }
 }

--- a/test/base.js
+++ b/test/base.js
@@ -67,7 +67,7 @@ describe('stylelint-webpack-plugin', function () {
         const error = stats.compilation.errors[0];
 
         expect(error.message).to.contain('test/fixtures/single-error/test.scss');
-        expect(error.message).to.contain('3:1 Unexpected missing end-of-source newline (no-missing-end-of-source-newline)');
+        expect(error.message).to.contain('3:1 stylelint: Unexpected missing end-of-source newline (no-missing-end-of-source-newline)');
       });
   });
 
@@ -81,7 +81,7 @@ describe('stylelint-webpack-plugin', function () {
         const warning = stats.compilation.warnings[0];
 
         expect(warning.message).to.contain('test/fixtures/rule-warning/test.scss');
-        expect(warning.message).to.contain('2:10 Expected "#FFF" to be "#fff" (color-hex-case)');
+        expect(warning.message).to.contain('2:10 stylelint: Expected "#FFF" to be "#fff" (color-hex-case)');
       });
   });
 

--- a/test/base.js
+++ b/test/base.js
@@ -24,7 +24,7 @@ describe('stylelint-webpack-plugin', function () {
   });
 
   it('works with a simple file', function () {
-    return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/lint-free') }))
+    return pack(assign({}, baseConfig(), { context: path.resolve('./test/fixtures/lint-free') }))
       .then(function (stats) {
         expect(stats.compilation.errors).to.have.length(0);
         expect(stats.compilation.warnings).to.have.length(0);
@@ -32,7 +32,7 @@ describe('stylelint-webpack-plugin', function () {
   });
 
   it('sends errors to the errors output only', function () {
-    return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/single-error') }))
+    return pack(assign({}, baseConfig(), { context: path.resolve('./test/fixtures/single-error') }))
       .then(function (stats) {
         expect(stats.compilation.errors).to.have.length(1, 'should have one error');
         expect(stats.compilation.warnings).to.have.length(0, 'should have no warnings');
@@ -40,7 +40,7 @@ describe('stylelint-webpack-plugin', function () {
   });
 
   it('works with multiple source files', function () {
-    return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/multiple-sources') }))
+    return pack(assign({}, baseConfig(), { context: path.resolve('./test/fixtures/multiple-sources') }))
       .then(function (stats) {
         expect(stats.compilation.errors).to.have.length(1);
         expect(stats.compilation.errors[0]).to.be.an.instanceof(Error);
@@ -50,10 +50,38 @@ describe('stylelint-webpack-plugin', function () {
   });
 
   it('sends warnings properly', function () {
-    return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/rule-warning') }))
+    return pack(assign({}, baseConfig(), { context: path.resolve('./test/fixtures/rule-warning') }))
       .then(function (stats) {
         expect(stats.compilation.errors).to.have.length(0);
         expect(stats.compilation.warnings).to.have.length(1);
+      });
+  });
+
+  it('pushes errors using the webpack formatter', function () {
+    const formatter = { formatter: 'webpack' };
+    return pack(assign({}, baseConfig(formatter), { context: path.resolve('./test/fixtures/single-error') }))
+      .then(function (stats) {
+        expect(stats.compilation.errors).to.have.length(1, 'should have one error');
+        expect(stats.compilation.warnings).to.have.length(0, 'should have no warnings');
+
+        const error = stats.compilation.errors[0];
+
+        expect(error.message).to.contain('test/fixtures/single-error/test.scss');
+        expect(error.message).to.contain('3:1 Unexpected missing end-of-source newline (no-missing-end-of-source-newline)');
+      });
+  });
+
+  it('pushes warnings using the webpack formatter', function () {
+    const formatter = { formatter: 'webpack' };
+    return pack(assign({}, baseConfig(formatter), { context: path.resolve('./test/fixtures/rule-warning') }))
+      .then(function (stats) {
+        expect(stats.compilation.errors).to.have.length(0);
+        expect(stats.compilation.warnings).to.have.length(1);
+
+        const warning = stats.compilation.warnings[0];
+
+        expect(warning.message).to.contain('test/fixtures/rule-warning/test.scss');
+        expect(warning.message).to.contain('2:10 Expected "#FFF" to be "#fff" (color-hex-case)');
       });
   });
 
@@ -68,7 +96,7 @@ describe('stylelint-webpack-plugin', function () {
       ]
     };
 
-    return pack(assign({}, baseConfig, config))
+    return pack(assign({}, baseConfig(), config))
       .then(expect.fail)
       .catch(function (err) {
         expect(err.message).to.equal(errorMessage);
@@ -85,7 +113,7 @@ describe('stylelint-webpack-plugin', function () {
       ]
     };
 
-    return pack(assign({}, baseConfig, config))
+    return pack(assign({}, baseConfig(), config))
       .then(expect.fail)
       .catch(function (err) {
         expect(err.message).to.contain('Failed to parse').and.contain('as JSON');
@@ -100,7 +128,7 @@ describe('stylelint-webpack-plugin', function () {
     };
 
     it('works by using stylelint#cosmiconfig under the hood', function () {
-      return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/lint-free') }))
+      return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/lint-free') }))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(0);
@@ -108,7 +136,7 @@ describe('stylelint-webpack-plugin', function () {
     });
 
     it('finds the right stylelintrc', function () {
-      return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/rule-warning') }))
+      return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/rule-warning') }))
         .then(function (stats) {
           expect(stats.compilation.warnings).to.have.length(1);
         });
@@ -151,7 +179,7 @@ describe('stylelint-webpack-plugin', function () {
       }
 
       it('throws when there is an error', function () {
-        return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/single-error') }))
+        return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/single-error') }))
           .then(expect.fail)
           .catch(function (err) {
             expect(err).to.be.instanceof(Error);
@@ -159,7 +187,7 @@ describe('stylelint-webpack-plugin', function () {
       });
 
       it('does not throw when there are only warnings', function () {
-        return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/rule-warning') }))
+        return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/rule-warning') }))
           .then(function (stats) {
             expect(stats.compilation.warnings).to.have.length(1);
           });
@@ -178,7 +206,7 @@ describe('stylelint-webpack-plugin', function () {
     };
 
     it('does not print warnings or errors when there are none', function () {
-      return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/lint-free') }))
+      return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/lint-free') }))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(0);
@@ -186,7 +214,7 @@ describe('stylelint-webpack-plugin', function () {
     });
 
     it('emits errors as warnings when asked to', function () {
-      return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/single-error') }))
+      return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/single-error') }))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(1);
@@ -196,7 +224,7 @@ describe('stylelint-webpack-plugin', function () {
     });
 
     it('still indicates that warnings are warnings, even when emitting errors as warnings too', function () {
-      return pack(assign({}, baseConfig, config, { context: path.resolve('./test/fixtures/rule-warning') }))
+      return pack(assign({}, baseConfig(), config, { context: path.resolve('./test/fixtures/rule-warning') }))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(1);
@@ -218,7 +246,7 @@ describe('stylelint-webpack-plugin', function () {
         ]
       };
 
-      return pack(assign({}, baseConfig, config))
+      return pack(assign({}, baseConfig(), config))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(0);
@@ -237,7 +265,7 @@ describe('stylelint-webpack-plugin', function () {
         ]
       };
 
-      return pack(assign({}, baseConfig, config))
+      return pack(assign({}, baseConfig(), config))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(0);

--- a/test/helpers/base-config.js
+++ b/test/helpers/base-config.js
@@ -3,29 +3,29 @@
 var StyleLintPlugin = require('../../');
 var webpack = require('./webpack');
 
-var configFilePath = getPath('./.stylelintrc');
+module.exports = function (options) {
+  var configFilePath = getPath('./.stylelintrc');
+  const pluginOptions = Object.assign({ configFile: configFilePath }, options || {});
 
-var baseConfig = {
-  entry: './index',
-  output: {
-    path: getPath('output')
-  },
-  plugins: [
-    new StyleLintPlugin({
-      configFile: configFilePath
-    })
-  ]
-};
+  var baseConfig = {
+    entry: './index',
+    output: {
+      path: getPath('output')
+    },
+    plugins: [
+      new StyleLintPlugin(pluginOptions)
+    ]
+  };
 
-if (typeof webpack.LoaderOptionsPlugin === 'undefined') {
-  baseConfig.debug = false;
-} else {
-  baseConfig.plugins.push(
-    new webpack.LoaderOptionsPlugin({
-      debug: false
-    })
-  );
-}
+  if (typeof webpack.LoaderOptionsPlugin === 'undefined') {
+    baseConfig.debug = false;
+  } else {
+    baseConfig.plugins.push(
+      new webpack.LoaderOptionsPlugin({
+        debug: false
+      })
+    );
+  }
 
 if (process.env.WEBPACK_VERSION === '4') {
   baseConfig.mode = 'development';


### PR DESCRIPTION
This PR addresses #133 by pushing errors to `compilation.warnings` and `compilations.errors` that follow the standard (and by standard we mean presently most frequently used) webpack error message format. This format is parsed by `webpack-stylish` and future reporters until the RFC for revamping webpack errors is implemented.

This PR:

- Adds `StylelintPluginError` in anticipation of future work. It inherits from `WebpackError` if the class exists (v2.5.0+).
- Adds `formatter-webpack.js` which utilizes `StylelintPluginError` and returns an array of error objects.
- Modifies `run-compilation.js` by consolidating the code for pushing warnings and errors to the `compilation` and handling the case in which a formatter returns an array instead of a string, while still accounting for a string (in the case of the default formatter).
- Requires that a user set the `options.formatter = 'webpack'` in the options for the plugin in the webpack config. (This will be noted in webpack-stylish as well). The README for this project was updated with that info.

And as an added bonus you now have tests touching the `options.formatter` property.