### PR TITLE
fix: fixes #153. webpack peerDep regression

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const path = require('path');
+
 const arrify = require('arrify');
 const assign = require('object-assign');
 const formatter = require('stylelint').formatters.string;
+
 const runCompilation = require('./lib/run-compilation');
 const LintDirtyModulesPlugin = require('./lib/lint-dirty-modules-plugin');
 const { defaultFilesGlob } = require('./lib/constants');

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "peerDependencies": {
     "stylelint": "^8.0.0",
-    "webpack": "^4.4.0"
+    "webpack": "^1.13.2 || ^2.7.0 || ^3.11.0 || ^4.4.0"
   },
   "dependencies": {
     "arrify": "^1.0.1",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #153. Regression introduced in 0.10.4.

### Breaking Changes

None. Restores peer version support for older webpack versions.

### Additional Info

The next version of this module should be a major version, with a minimum webpack support of v4.6.0.
