### PR TITLE
fix: handle compilation.fileTimestamps for webpack 4

### DIFF
--- a/lib/lint-dirty-modules-plugin.js
+++ b/lib/lint-dirty-modules-plugin.js
@@ -1,6 +1,7 @@
 const assign = require('object-assign');
 const { defaultTo } = require('ramda');
 const micromatch = require('micromatch');
+
 const runCompilation = require('./run-compilation');
 
 /**
@@ -63,6 +64,21 @@ LintDirtyModulesPlugin.prototype.getChangedFiles = function getChangedFiles(
   fileTimestamps,
   glob
 ) {
+  // Webpack >= 4
+  if (fileTimestamps instanceof Map) {
+    const changedFiles = [];
+    for (const [filename, timestamp] of fileTimestamps.entries()) {
+      if (
+        hasFileChanged.call(this, filename, timestamp) &&
+        micromatch.isMatch(filename, glob)
+      ) {
+        changedFiles.push(filename);
+      }
+    }
+    return changedFiles;
+  }
+
+  // Webpack < 4
   return Object.keys(fileTimestamps).filter(
     (filename) =>
       hasFileChanged.call(this, filename, fileTimestamps[filename]) &&
@@ -71,9 +87,13 @@ LintDirtyModulesPlugin.prototype.getChangedFiles = function getChangedFiles(
 };
 
 function hasFileChanged(filename, timestamp) {
+  const prevTimestamp =
+    this.prevTimestamps instanceof Map
+      ? this.prevTimestamps.get(filename)
+      : this.prevTimestamps[filename];
+
   return (
-    defaultTo(this.startTime)(this.prevTimestamps[filename]) <
-    defaultTo(Infinity)(timestamp)
+    defaultTo(this.startTime)(prevTimestamp) < defaultTo(Infinity)(timestamp)
   );
 }
 

--- a/test/lib/lint-dirty-modules-plugin.js
+++ b/test/lib/lint-dirty-modules-plugin.js
@@ -4,6 +4,7 @@ const td = require('testdouble');
 const runCompilation = td.replace('../../lib/run-compilation');
 
 const { string: formatter } = require('stylelint').formatters;
+
 const LintDirtyModulesPlugin = require('../../lib/lint-dirty-modules-plugin');
 const { defaultFilesGlob: glob } = require('../../lib/constants');
 
@@ -44,9 +45,7 @@ describe('lint-dirty-modules-plugin', () => {
     const doneStub = td.function();
     LintDirtyModulesPluginCloned.prototype.lint = lintStub;
     const compilationMock = {
-      fileTimestamps: {
-        '/updated.scss': 5,
-      },
+      fileTimestamps: new Map([['/updated.scss', 5]]),
     };
     const plugin = new LintDirtyModulesPluginCloned(compilerMock, optionsMock);
 
@@ -60,21 +59,21 @@ describe('lint-dirty-modules-plugin', () => {
     let getChangedFilesStub;
     let doneStub;
     let compilationMock;
-    const fileTimestamps = {
-      '/test/changed.scss': 5,
-      '/test/newly-created.scss': 5,
-    };
+    const fileTimestamps = new Map([
+      ['/test/changed.scss', 5],
+      ['/test/newly-created.scss', 5],
+    ]);
     let pluginMock;
     beforeEach(() => {
       getChangedFilesStub = td.function();
       doneStub = td.function();
       compilationMock = {
-        fileTimestamps: {},
+        fileTimestamps: new Map(),
       };
-      td.when(getChangedFilesStub({}, glob)).thenReturn([]);
+      td.when(getChangedFilesStub(new Map(), glob)).thenReturn([]);
       td
         .when(getChangedFilesStub(fileTimestamps, glob))
-        .thenReturn(Object.keys(fileTimestamps));
+        .thenReturn(Array.from(fileTimestamps.keys()));
       pluginMock = {
         getChangedFiles: getChangedFilesStub,
         compiler: compilerMock,
@@ -122,7 +121,7 @@ describe('lint-dirty-modules-plugin', () => {
         compilationMock,
         doneStub
       );
-      optionsMock.files = Object.keys(fileTimestamps);
+      optionsMock.files = Array.from(fileTimestamps.keys());
 
       td.verify(runCompilation(optionsMock, compilerMock, doneStub));
     });
@@ -136,20 +135,20 @@ describe('lint-dirty-modules-plugin', () => {
         options: optionsMock,
         isFirstRun: true,
         startTime: 10,
-        prevTimestamps: {
-          '/test/changed.scss': 5,
-          '/test/removed.scss': 5,
-          '/test/changed.js': 5,
-        },
+        prevTimestamps: new Map([
+          ['/test/changed.scss', 5],
+          ['/test/removed.scss', 5],
+          ['/test/changed.js', 5],
+        ]),
       };
     });
 
     it('returns changed style files', () => {
-      const fileTimestamps = {
-        '/test/changed.scss': 20,
-        '/test/changed.js': 20,
-        '/test/newly-created.scss': 15,
-      };
+      const fileTimestamps = new Map([
+        ['/test/changed.scss', 20],
+        ['/test/changed.js', 20],
+        ['/test/newly-created.scss', 15],
+      ]);
 
       const changedFiles = LintDirtyModulesPluginCloned.prototype.getChangedFiles.call(
         pluginMock,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
`lintDirtyModulesOnly` is currently broken for webpack 4 (it doesn't correctly identify the changed files so nothing ever gets linted).

[Since webpack 4.0.0](https://github.com/webpack/webpack/releases/tag/v4.0.0), `compilation.fileTimestamps` is now a Map object.  `LintDirtyModulesPlugin` currently assumes that it is a plain object, so `getChangedFiles` always returns an empty array. This PR fixes that.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
Nothing - it handles `compilation.fileTimestamps` as a plain object if it's not a Map. I have tested it with an application using Webpack 3 and it works correctly.

I've updated the tests to use Map objects. The tests could be set up to handle Webpack 3, but the suite is only set up for Webpack 4 so I haven't bothered.