### PR TITLE
Field `files` in options support negated patterns.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const arrify = require('arrify');
 const assign = require('object-assign');
 const formatter = require('stylelint').formatters.string;
@@ -20,10 +18,8 @@ function apply(options, compiler) {
     {
       // Default Glob is any directory level of scss and/or sass file,
       // under webpack's context and specificity changed via globbing patterns
-      files: arrify(options.files || defaultFilesGlob).map((file) =>
-        path.join(context, '/', file)
-      ),
-      context,
+      files: arrify(options.files || defaultFilesGlob),
+      filesCwd: context,
     }
   );
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
FIles field uses globby package, which support negated patterns.
In my project, I want to lint all css files except `iconfont.css` which was generated automatic by [iconfont.cn](http://iconfont.cn/).
Then, I find that pattern starts with `!` do not have correct effect.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
Files in root folder should not start with `!`.

### Additional Info
