### PR TITLE
Support absolute paths in files array

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ function apply(options, compiler) {
     {
       // Default Glob is any directory level of scss and/or sass file,
       // under webpack's context and specificity changed via globbing patterns
-      files: arrify(options.files || defaultFilesGlob).map((file) =>
-        path.join(context, '/', file)
+      files: arrify(options.files || defaultFilesGlob).map(
+        (file) => (path.isAbsolute(file) ? file : path.join(context, '/', file))
       ),
       context,
     }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

My context is currently the `config` directory of my application as opposed to the root of it (and I'm sure others have it configured this way too). This means I have to use `../src/**/*.css` and can't use an absolute path to the glob (i.e. `/tmp/project/src/**/*.css`).

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This will change the handling of any paths starting with a slash, using them as they are instead of joining the context onto the start of them. It should be rare that users are adding the leading slash anyway, as it's a bit of an odd thing to do. The migration path is to stop putting a leading slash on your path (or stripping it away with `.slice(1)`).
