### PR TITLE
update stylelint to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "webpack-plugin"
   ],
   "peerDependencies": {
-    "stylelint": "^8.0.0 || ^9.2.0",
+    "stylelint": "^8.0.0 || ^9.2.0 || ^10.1.0",
     "webpack": "^1.13.2 || ^2.7.0 || ^3.11.0 || ^4.4.0"
   },
   "dependencies": {
@@ -84,7 +84,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.11.1",
     "standard-version": "^4.3.0",
-    "stylelint": "^9.2.1",
+    "stylelint": "^10.1.0",
     "testdouble": "^3.3.1",
     "webpack": "^4.4.1",
     "webpack-defaults": "^2.1.1"


### PR DESCRIPTION
This PR contains an update of NPM dependencies to fix #174 

### Breaking Changes

This PR doesn't introduce breaking change as **Stylelint v10** doesn't have any.

### Additional Info

This is to fix NPM warning about peerDependencies when using latest **Stylelint** version.
