### PR TITLE
fix: options variable in apply function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class StylelintWebpackPlugin {
 
   apply(compiler) {
     const context = this.getContext(compiler);
-    const { options } = this;
+    const options = { ...this.options };
 
     options.files = arrify(options.files).map((file) =>
       join(context, '/', file)


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Fix: #191

Currently, `options` variable is shallow copy. (`const { options } = this`)
When webpack has config multiple and `file` is relative, `.join(context, '/', file)` will be called multiple times.
So, `options.files` path is broken.

### Breaking Changes
Nothing

### Additional Info