### PR TITLE
feat: make possible to define official formatter as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ If `true`, `stylelint` will fix as many errors as possible. The fixes are made t
 
 ### `formatter`
 
-- Type: `Function`
-- Default: `require('stylelint').formatters.string`
+- Type: `String|Function`
+- Default: `'string'`
 
-Specify the formatter that you would like to use to format your results.
+Specify the formatter that you would like to use to format your results. See [formatter option](https://stylelint.io/user-guide/node-api#formatter).
 
 ### `lintDirtyModulesOnly`
 

--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -2,21 +2,39 @@ import validateOptions from 'schema-utils';
 
 import schema from './options.json';
 
-export default function getOptions(options) {
+export default function getOptions(pluginOptions) {
+  const options = {
+    files: '**/*.s?(c|a)ss',
+    formatter: 'string',
+    stylelintPath: 'stylelint',
+    ...pluginOptions,
+  };
+
   validateOptions(schema, options, {
     name: 'Stylelint Webpack Plugin',
     baseDataPath: 'options',
   });
 
-  const stylelintPath = options.stylelintPath || 'stylelint';
-
   // eslint-disable-next-line
-  const { formatters } = require(stylelintPath);
+  const stylelint = require(options.stylelintPath);
 
-  return {
-    files: '**/*.s?(c|a)ss',
-    formatter: formatters.string,
-    stylelintPath,
-    ...options,
-  };
+  options.formatter = getFormatter(stylelint, options.formatter);
+
+  return options;
+}
+
+function getFormatter({ formatters }, formatter) {
+  if (typeof formatter === 'function') {
+    return formatter;
+  }
+
+  // Try to get oficial formatter
+  if (
+    typeof formatter === 'string' &&
+    typeof formatters[formatter] === 'function'
+  ) {
+    return formatters[formatter];
+  }
+
+  return formatters.string;
 }

--- a/src/options.json
+++ b/src/options.json
@@ -28,7 +28,7 @@
     },
     "formatter": {
       "description": "Specify the formatter that you would like to use to format your results.",
-      "instanceof": "Function"
+      "anyOf": [{ "type": "string" }, { "instanceof": "Function" }]
     },
     "lintDirtyModulesOnly": {
       "description": "Lint only changed files, skip lint on start.",

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,0 +1,53 @@
+import { formatters } from 'stylelint';
+
+import pack from './utils/pack';
+
+describe('formatter', () => {
+  it('should use default formatter', (done) => {
+    const compiler = pack('error');
+
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(true);
+      expect(stats.compilation.errors[0].message).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should use default formatter when invalid', (done) => {
+    const compiler = pack('error', { formatter: 'invalid' });
+
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(true);
+      expect(stats.compilation.errors[0].message).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should use string formatter', (done) => {
+    const compiler = pack('error', { formatter: 'json' });
+
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(true);
+      expect(stats.compilation.errors[0].message).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should use function formatter', (done) => {
+    const compiler = pack('error', { formatter: formatters.verbose });
+
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(true);
+      expect(stats.compilation.errors[0].message).toBeTruthy();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The formatter option only accepted function, with this feature we can also set official formatters as string

```js
const StylelintPlugin = require('stylelint-webpack-plugin');

module.exports = {
  // ...
  plugins: [
    new StylelintPlugin({
      formatter: 'json' // See https://stylelint.io/user-guide/node-api#formatter
    )
  ],
  // ...
};
```

### Additional Info

Resolve #201 
