### PR TITLE
fix: use better micromatch extglobs

### DIFF
--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -24,7 +24,7 @@ import schema from './options.json';
  */
 export default function getOptions(pluginOptions) {
   const options = {
-    files: '**/*.s?(c|a)ss',
+    files: '**/*.(s(c|a)ss|css)',
     formatter: 'string',
     stylelintPath: 'stylelint',
     ...pluginOptions,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [x] **typo fix**

### Motivation / Use-Case
It seems that the default value for the `files` option has an issue.
If the purpose of `**/*.s?(c|a)ss` is to match just `scss` or `sass` files so why we need `?` after `s`
I think the `**/*.(s(c|a)ss|css)` is better for supporting `css`, `scss` & `sass` files.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

