### PR TITLE
Add stylelint to error for generic exception handling

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -67,7 +67,7 @@ export default function linter(lint, options, compiler, callback) {
         'StylelintWebpackPlugin',
         (compilation, next) => {
           // @ts-ignore
-          compilation.errors.push(new StylelintError(e.message));
+          compilation.errors.push(`stylelint\n${e.message}`);
           next();
         }
       );

--- a/test/emit-error.test.js
+++ b/test/emit-error.test.js
@@ -21,7 +21,7 @@ describe('emit error', () => {
       expect(stats.hasWarnings()).toBe(false);
       expect(stats.hasErrors()).toBe(true);
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain('error/test.scss');
+      expect(errors[0].message).toContain('stylelint\nerror/test.scss');
       done();
     });
   });
@@ -34,7 +34,7 @@ describe('emit error', () => {
       expect(stats.hasWarnings()).toBe(false);
       expect(stats.hasErrors()).toBe(true);
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain('warning/test.scss');
+      expect(errors[0].message).toContain('stylelint\nwarning/test.scss');
       done();
     });
   });

--- a/test/empty.test.js
+++ b/test/empty.test.js
@@ -21,7 +21,7 @@ describe('empty', () => {
       expect(stats.hasWarnings()).toBe(false);
       expect(stats.hasErrors()).toBe(true);
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain('No files matching the pattern');
+      expect(errors[0].message).toContain('stylelint\nNo files matching the pattern');
       done();
     });
   });

--- a/test/fail-on-config.test.js
+++ b/test/fail-on-config.test.js
@@ -12,7 +12,7 @@ describe('fail on config', () => {
       expect(stats.hasWarnings()).toBe(false);
       expect(stats.hasErrors()).toBe(true);
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toMatch(/Map keys must be unique/);
+      expect(errors[0].message).toMatch('stylelint\nMap keys must be unique');
       done();
     });
   });


### PR DESCRIPTION
For generic exception handling (ie errors thrown during parsing) add stylelint to the error message so it's a bit more obvious where a vague js exception came from.

Before 
<img width="499" alt="Screen Shot 2020-11-10 at 11 04 19 PM" src="https://user-images.githubusercontent.com/7935599/98764103-1729e980-23a9-11eb-89cd-bbeaa2b711aa.png">

After
<img width="466" alt="Screen Shot 2020-11-10 at 10 46 59 PM" src="https://user-images.githubusercontent.com/7935599/98764121-1f822480-23a9-11eb-8af3-aad89c030b6a.png">


This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
When I run my webpack build with stylelint-webpack-plugin and an unexpected exception occurs, the error message doesn't indicate what plugin it came from, making it especially hard to debug.
Related to https://github.com/stylelint/stylelint/pull/5012