### PR TITLE
Process only files from endpoints not all in project

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,4 @@
-name: "Dependency Review"
+name: 'Dependency Review'
 on: [pull_request]
 
 permissions:
@@ -8,7 +8,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Repository"
+      - name: 'Checkout Repository'
         uses: actions/checkout@v3
-      - name: "Dependency Review"
+      - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When running in webpack all the files in a project folder are processed not only the files that are coming from the endpoints. The solution is made on similar functionality from eslint-webpack-plugin.

### Breaking Changes
Hopefully none

### Additional Info
