### PR TITLE
chore: improve unit tests feedback loop by making them asynchronous

### DIFF
--- a/test/context.test.js
+++ b/test/context.test.js
@@ -3,25 +3,19 @@ import { join } from 'path';
 import pack from './utils/pack';
 
 describe('context', () => {
-  it('absolute', (done) => {
+  it('absolute', async () => {
     const compiler = pack('good', {
       context: join(__dirname, 'fixtures/good'),
     });
-
-    compiler.run((err, stats) => {
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('relative', (done) => {
+  it('relative', async () => {
     const compiler = pack('good', { context: '../good/' });
-
-    compiler.run((err, stats) => {
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/emit-error.test.js
+++ b/test/emit-error.test.js
@@ -1,58 +1,39 @@
 import pack from './utils/pack';
 
 describe('emit error', () => {
-  it('should not emit errors if emitError is false', (done) => {
+  it('should not emit errors if emitError is false', async () => {
     const compiler = pack('error', { emitError: false });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should emit errors if emitError is undefined', (done) => {
+  it('should emit errors if emitError is undefined', async () => {
     const compiler = pack('error');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should emit errors if emitError is true', (done) => {
+  it('should emit errors if emitError is true', async () => {
     const compiler = pack('error', { emitError: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should emit errors, but not warnings if emitError is true and emitWarning is false', (done) => {
+  it('should emit errors, but not warnings if emitError is true and emitWarning is false', async () => {
     const compiler = pack('full-of-problems', {
       emitError: true,
       emitWarning: false,
     });
 
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should emit errors and warnings if emitError is true and emitWarning is undefined', (done) => {
+  it('should emit errors and warnings if emitError is true and emitWarning is undefined', async () => {
     const compiler = pack('full-of-problems', { emitError: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -1,58 +1,38 @@
 import pack from './utils/pack';
 
 describe('emit warning', () => {
-  it('should not emit warnings if emitWarning is false', (done) => {
+  it('should not emit warnings if emitWarning is false', async () => {
     const compiler = pack('warning', { emitWarning: false });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
   });
 
-  it('should emit warnings if emitWarning is undefined', (done) => {
+  it('should emit warnings if emitWarning is undefined', async () => {
     const compiler = pack('warning');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
   });
 
-  it('should emit warnings if emitWarning is true', (done) => {
+  it('should emit warnings if emitWarning is true', async () => {
     const compiler = pack('warning', { emitWarning: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
   });
 
-  it('should emit warnings, but not warnings if emitWarning is true and emitError is false', (done) => {
+  it('should emit warnings, but not warnings if emitWarning is true and emitError is false', async () => {
     const compiler = pack('full-of-problems', {
       emitWarning: true,
       emitError: false,
     });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should emit warnings and errors if emitWarning is true and emitError is undefined', (done) => {
+  it('should emit warnings and errors if emitWarning is true and emitError is undefined', async () => {
     const compiler = pack('full-of-problems', { emitWarning: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/empty.test.js
+++ b/test/empty.test.js
@@ -1,22 +1,18 @@
-import { join } from 'path';
-
-import webpack from 'webpack';
-
 import StylelintWebpackPlugin from '../src';
 
-describe('empty', () => {
-  it('no error when no files matching', (done) => {
-    const compiler = webpack({
-      context: join(__dirname, 'fixtures', 'empty'),
-      mode: 'development',
-      entry: './index',
-      plugins: [new StylelintWebpackPlugin()],
-    });
+import pack from './utils/pack';
 
-    compiler.run((err, stats) => {
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+describe('empty', () => {
+  it('no error when no files matching', async () => {
+    const compiler = pack(
+      'empty',
+      {},
+      {
+        plugins: [new StylelintWebpackPlugin()],
+      },
+    );
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -5,29 +5,21 @@ describe('error', () => {
     jest.restoreAllMocks();
   });
 
-  it('should return error if file is bad', (done) => {
+  it('should return error if file is bad', async () => {
     const compiler = pack('error');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should propagate stylelint exceptions as errors', (done) => {
+  it('should propagate stylelint exceptions as errors', async () => {
     jest.mock('stylelint', () => {
       throw new Error('Oh no!');
     });
 
     const compiler = pack('good');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/exclude.test.js
+++ b/test/exclude.test.js
@@ -1,36 +1,24 @@
 import pack from './utils/pack';
 
 describe('exclude', () => {
-  it('should exclude with globs', (done) => {
+  it('should exclude with globs', async () => {
     const compiler = pack('exclude', { exclude: ['*test*'] });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should exclude files', (done) => {
+  it('should exclude files', async () => {
     const compiler = pack('exclude', { exclude: ['test.scss'] });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should exclude folders', (done) => {
+  it('should exclude folders', async () => {
     const compiler = pack('exclude-folder', { exclude: ['folder'] });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/fail-on-config.test.js
+++ b/test/fail-on-config.test.js
@@ -3,16 +3,13 @@ import { join } from 'path';
 import pack from './utils/pack';
 
 describe('fail on config', () => {
-  it('fails when .stylelintrc is not a proper format', (done) => {
+  it('fails when .stylelintrc is not a proper format', async () => {
     const configFile = join(__dirname, '.badstylelintrc');
     const compiler = pack('error', { configFile });
-
-    compiler.run((err, stats) => {
-      const { errors } = stats.compilation;
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(errors).toHaveLength(1);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    const { errors } = stats.compilation;
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(errors).toHaveLength(1);
   });
 });

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -1,33 +1,22 @@
 import pack from './utils/pack';
 
 describe('fail on error', () => {
-  it('should emits errors', (done) => {
+  it('should emits errors', async () => {
     const compiler = pack('error', { failOnError: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should emit warnings when disabled', (done) => {
+  it('should emit warnings when disabled', async () => {
     const compiler = pack('error', { failOnError: false });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(false);
-      expect(stats.hasWarnings()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
+    expect(stats.hasWarnings()).toBe(true);
   });
 
-  it('should correctly indentifies a success', (done) => {
+  it('should correctly indentifies a success', async () => {
     const compiler = pack('good', { failOnError: true });
-
-    compiler.run((err) => {
-      expect(err).toBeNull();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/fail-on-warning.test.js
+++ b/test/fail-on-warning.test.js
@@ -1,22 +1,15 @@
 import pack from './utils/pack';
 
 describe('fail on warning', () => {
-  it('should emits errors', (done) => {
+  it('should emits errors', async () => {
     const compiler = pack('warning', { failOnWarning: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should correctly indentifies a success', (done) => {
+  it('should correctly indentifies a success', async () => {
     const compiler = pack('good', { failOnWarning: true });
-
-    compiler.run((err) => {
-      expect(err).toBeNull();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -3,51 +3,35 @@ import { formatters } from 'stylelint';
 import pack from './utils/pack';
 
 describe('formatter', () => {
-  it('should use default formatter', (done) => {
+  it('should use default formatter', async () => {
     const compiler = pack('error');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBeTruthy();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toBeTruthy();
   });
 
-  it('should use default formatter when invalid', (done) => {
+  it('should use default formatter when invalid', async () => {
     const compiler = pack('error', { formatter: 'invalid' });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBeTruthy();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toBeTruthy();
   });
 
-  it('should use string formatter', (done) => {
+  it('should use string formatter', async () => {
     const compiler = pack('error', { formatter: 'json' });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBeTruthy();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toBeTruthy();
   });
 
-  it('should use function formatter', (done) => {
+  it('should use function formatter', async () => {
     const compiler = pack('error', { formatter: formatters.verbose });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBeTruthy();
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toBeTruthy();
   });
 });

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -3,7 +3,7 @@ import StylelintPlugin from '../src';
 import pack from './utils/pack';
 
 describe('multiple instances', () => {
-  it("should don't fail", (done) => {
+  it("should don't fail", async () => {
     const compiler = pack(
       'multiple',
       {},
@@ -15,15 +15,12 @@ describe('multiple instances', () => {
       },
     );
 
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should fail on first instance', (done) => {
+  it('should fail on first instance', async () => {
     const compiler = pack(
       'multiple',
       {},
@@ -35,15 +32,12 @@ describe('multiple instances', () => {
       },
     );
 
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 
-  it('should fail on second instance', (done) => {
+  it('should fail on second instance', async () => {
     const compiler = pack(
       'multiple',
       {},
@@ -55,11 +49,8 @@ describe('multiple instances', () => {
       },
     );
 
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/ok.test.js
+++ b/test/ok.test.js
@@ -1,14 +1,10 @@
 import pack from './utils/pack';
 
 describe('ok', () => {
-  it("should don't throw error if file is ok", (done) => {
+  it("should don't throw error if file is ok", async () => {
     const compiler = pack('good');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/output-report.test.js
+++ b/test/output-report.test.js
@@ -5,22 +5,18 @@ import { existsSync } from 'fs-extra';
 import pack from './utils/pack';
 
 describe('output report', () => {
-  it('should output report a default formatter', (done) => {
+  it('should output report a default formatter', async () => {
     const filePath = 'report.txt';
     const compiler = pack('error', {
       outputReport: { filePath },
     });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(existsSync(join(compiler.outputPath, filePath))).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(existsSync(join(compiler.outputPath, filePath))).toBe(true);
   });
 
-  it('should output report with a custom formatter', (done) => {
+  it('should output report with a custom formatter', async () => {
     const filePath = join(__dirname, 'output', 'report.json');
     const compiler = pack('error', {
       outputReport: {
@@ -28,13 +24,9 @@ describe('output report', () => {
         formatter: 'json',
       },
     });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(existsSync(filePath)).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(existsSync(filePath)).toBe(true);
   });
 });

--- a/test/quiet.test.js
+++ b/test/quiet.test.js
@@ -1,25 +1,17 @@
 import pack from './utils/pack';
 
 describe('quiet', () => {
-  it('should not emit warnings if quiet is set', (done) => {
+  it('should not emit warnings if quiet is set', async () => {
     const compiler = pack('warning', { quiet: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
-  it('should emit errors, but not emit warnings if quiet is set', (done) => {
+  it('should emit errors, but not emit warnings if quiet is set', async () => {
     const compiler = pack('full-of-problems', { quiet: true });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/stylelint-ignore.test.js
+++ b/test/stylelint-ignore.test.js
@@ -1,13 +1,10 @@
 import pack from './utils/pack';
 
 describe('stylelint ignore', () => {
-  it('should ignore file', (done) => {
+  it('should ignore file', async () => {
     const compiler = pack('stylelint-ignore');
-
-    compiler.run((err, stats) => {
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/stylelint-lint.test.js
+++ b/test/stylelint-lint.test.js
@@ -21,40 +21,34 @@ describe('stylelint lint', () => {
     mockLintFiles.mockClear();
   });
 
-  it('should lint one file', (done) => {
+  it('should lint one file', async () => {
     const compiler = pack('lint-one', { configFile: null });
-
-    compiler.run((err) => {
-      const files = [expect.stringMatching('test.scss')];
-      expect(mockLintFiles).toHaveBeenCalledWith({
-        cache: false,
-        cacheLocation:
-          'node_modules/.cache/stylelint-webpack-plugin/.stylelintcache',
-        configFile: null,
-        files,
-      });
-      expect(err).toBeNull();
-      done();
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
+    const files = [expect.stringMatching('test.scss')];
+    expect(mockLintFiles).toHaveBeenCalledWith({
+      cache: false,
+      cacheLocation:
+        'node_modules/.cache/stylelint-webpack-plugin/.stylelintcache',
+      configFile: null,
+      files,
     });
   });
 
-  it('should lint two files', (done) => {
+  it('should lint two files', async () => {
     const compiler = pack('lint-two', { configFile: null });
-
-    compiler.run((err) => {
-      const files = [
-        expect.stringMatching(/test[12]\.scss$/),
-        expect.stringMatching(/test[12]\.scss$/),
-      ];
-      expect(mockLintFiles).toHaveBeenCalledWith({
-        cache: false,
-        cacheLocation:
-          'node_modules/.cache/stylelint-webpack-plugin/.stylelintcache',
-        configFile: null,
-        files,
-      });
-      expect(err).toBeNull();
-      done();
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
+    const files = [
+      expect.stringMatching(/test[12]\.scss$/),
+      expect.stringMatching(/test[12]\.scss$/),
+    ];
+    expect(mockLintFiles).toHaveBeenCalledWith({
+      cache: false,
+      cacheLocation:
+        'node_modules/.cache/stylelint-webpack-plugin/.stylelintcache',
+      configFile: null,
+      files,
     });
   });
 });

--- a/test/stylelint-path.test.js
+++ b/test/stylelint-path.test.js
@@ -3,16 +3,12 @@ import { join } from 'path';
 import pack from './utils/pack';
 
 describe('stylelint path', () => {
-  it('should use another instance of stylelint via stylelintPath config', (done) => {
+  it('should use another instance of stylelint via stylelintPath config', async () => {
     const stylelintPath = join(__dirname, 'mock/stylelint');
     const compiler = pack('stylelint-path', { stylelintPath });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toContain('Fake error');
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toContain('Fake error');
   });
 });

--- a/test/symbols.test.js
+++ b/test/symbols.test.js
@@ -1,14 +1,10 @@
 import pack from './utils/pack';
 
 describe('symbols', () => {
-  it('should return error', (done) => {
+  it('should return error', async () => {
     const compiler = pack('[symbols]');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(true);
   });
 });

--- a/test/threads.test.js
+++ b/test/threads.test.js
@@ -8,15 +8,11 @@ import getStylelint from '../src/getStylelint';
 import pack from './utils/pack';
 
 describe('Threading', () => {
-  it("should don't throw error if file is ok with threads", (done) => {
+  it("should don't throw error if file is ok with threads", async () => {
     const compiler = pack('good', { threads: 2 });
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
   });
 
   test('Threaded interface should look like non-threaded interface', async () => {

--- a/test/utils/pack.js
+++ b/test/utils/pack.js
@@ -2,5 +2,27 @@ import webpack from 'webpack';
 
 import conf from './conf';
 
-export default (context, pluginConf = {}, webpackConf = {}) =>
-  webpack(conf(context, pluginConf, webpackConf));
+export default (context, pluginConf = {}, webpackConf = {}) => {
+  const compiler = webpack(conf(context, pluginConf, webpackConf));
+
+  return {
+    get outputPath() {
+      return compiler.outputPath;
+    },
+
+    runAsync() {
+      return new Promise((resolve, reject) => {
+        compiler.run((err, stats) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(stats);
+          }
+        });
+      });
+    },
+    watch(options, fn) {
+      return compiler.watch(options, fn);
+    },
+  };
+};

--- a/test/warning.test.js
+++ b/test/warning.test.js
@@ -1,14 +1,10 @@
 import pack from './utils/pack';
 
 describe('warning', () => {
-  it('should emit warnings', (done) => {
+  it('should emit warnings', async () => {
     const compiler = pack('warning');
-
-    compiler.run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(true);
-      expect(stats.hasErrors()).toBe(false);
-      done();
-    });
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(true);
+    expect(stats.hasErrors()).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
I'm working on #342 and when a test failed, it had to time out to display the error.
Using async/await makes it so that when a test fails, the error is printed immediately.

This reduces the feedback loop and makes it easier to make changes.

The downside is that it hides the webpack API behind an indirection layer.
I'll let you judge if this is something you want to have or not.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
N/A

### Additional Info

N/A
