### PR TITLE
fix: output report generation

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -152,12 +152,12 @@ function linter(key, options, compilation) {
         return;
       }
 
-      const content = outputReport.formatter;
-      (await loadFormatter(stylelint, outputReport.formatter))(
-        results,
-        returnValue,
-      );
-      formatter(results, returnValue);
+      const content = outputReport.formatter
+        ? (await loadFormatter(stylelint, outputReport.formatter))(
+            results,
+            returnValue,
+          )
+        : formatter(results, returnValue);
 
       let { filePath } = outputReport;
       if (!isAbsolute(filePath)) {

--- a/test/output-report.test.js
+++ b/test/output-report.test.js
@@ -29,7 +29,7 @@ describe('output report', () => {
     expect(stats.hasErrors()).toBe(true);
     expect(existsSync(filePath)).toBe(true);
     expect(JSON.parse(readFileSync(filePath, 'utf8'))).toMatchObject([
-      { source: expect.stringContaining('error/test.scss') },
+      { source: expect.stringContaining('test.scss') },
     ]);
   });
 });

--- a/test/output-report.test.js
+++ b/test/output-report.test.js
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-import { existsSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs-extra';
 
 import pack from './utils/pack';
 
@@ -28,5 +28,8 @@ describe('output report', () => {
     expect(stats.hasWarnings()).toBe(false);
     expect(stats.hasErrors()).toBe(true);
     expect(existsSync(filePath)).toBe(true);
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toMatchObject([
+      { source: expect.stringContaining('error/test.scss') },
+    ]);
   });
 });


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
The changes in https://github.com/webpack-contrib/stylelint-webpack-plugin/pull/300 broke the `outputReport` functionality, specifically:
```
-      const content = outputReport.formatter
-        ? loadFormatter(stylelint, outputReport.formatter)(results)
-        : formatter(results);
+      const content = outputReport.formatter;
+      loadFormatter(stylelint, outputReport.formatter)(results, returnValue);
+      formatter(results, returnValue);
```
means that the `content` that is written to the output file, is always just the `.toString()` of the `outputReport.formatter` itself.  For example:
```
outputReport: {
  filePath: "stylelint-report.json"
  formatter: "json",
}

> cat stylelint-report.json
json
```

I have not added additional tests for this change, as I am unable to run the existing test suite:
```
node --version
v18.16.1
```
```
npm install
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.

> stylelint-webpack-plugin@5.0.0 prepare
> husky && npm run build


> stylelint-webpack-plugin@5.0.0 prebuild
> npm run clean


> stylelint-webpack-plugin@5.0.0 clean
> del-cli dist types


> stylelint-webpack-plugin@5.0.0 build
> npm-run-all -p "build:**"


> stylelint-webpack-plugin@5.0.0 build:types
> tsc --declaration --emitDeclarationOnly --outDir types && prettier "types/**/*.ts" --write


> stylelint-webpack-plugin@5.0.0 build:code
> cross-env NODE_ENV=production babel src -d dist --copy-files

Successfully compiled 7 files with Babel (173ms).
types/getStylelint.d.ts 106ms
types/index.d.ts 6ms
types/linter.d.ts 7ms
types/options.d.ts 5ms
types/StylelintError.d.ts 1ms
types/utils.d.ts 4ms
types/worker.d.ts 1ms (unchanged)

added 1282 packages, and audited 1283 packages in 6s

218 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

```
npm run test:only

...
 FAIL  test/emit-error.test.js
  ● Test suite failed to run

    A jest worker process (pid=88843) was terminated by another process: signal=SIGSEGV, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)

 FAIL  test/stylelint-ignore.test.js
  ● Test suite failed to run

    A jest worker process (pid=88842) was terminated by another process: signal=SIGSEGV, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)

 FAIL  test/output-report.test.js
  ● Test suite failed to run

    A jest worker process (pid=88844) was terminated by another process: signal=SIGSEGV, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)


Test Suites: 15 failed, 9 passed, 24 total
Tests:       19 passed, 19 total
Snapshots:   6 passed, 6 total
Time:        3.327 s
Ran all test suites.
```

Please note that the existing `output-report.test.js` test cases do not assert the content of the output file at all, just that it was created.  This will be why the tests did not catch this regression when it occurred.